### PR TITLE
singleton handling in GameManager class

### DIFF
--- a/fake_the_spire/views.py
+++ b/fake_the_spire/views.py
@@ -18,8 +18,6 @@ class GameManager:
         if GameManager._instance is not None:
             if reset:
                 GameManager._instance.current_game = Game('character')
-            else:
-                raise Exception("This class is a singleton!")
         self.current_game = Game('character')
 
 


### PR DESCRIPTION
Removed the part of the code where an exception is raised when GameManager instance is not None. This was causing unnecessary halting of the program in a situation that could be handled differently. Now, the GameManager will always create a new game, regardless of the instance state.