### PR TITLE
Add block and vulnerability mechanics to combat tests

### DIFF
--- a/fake_the_spire/combat.py
+++ b/fake_the_spire/combat.py
@@ -157,9 +157,21 @@ class Combat(Floor):
         self.player['energy'] = 0
         self.player['discard_pile'].update(self.player['hand'])
         self.player['hand'] = {}
+        for decriment_optional_key in ['vulnerable', 'weak']:
+            if decriment_optional_key in self.player['optional_dict']:
+                self.player['optional_dict'][decriment_optional_key] = (
+                        self.player['optional_dict'][decriment_optional_key] - 1)
+                if self.player['optional_dict'][decriment_optional_key] < 0:
+                    self.player['optional_dict'][decriment_optional_key] = 0
         for enemy in self.enemy_list:
-            enemy_action = random.choice(enemy['actions'])
-            self.take_action(f"{enemy_action} {enemy['id']} player")
+            enemy_action, target = random.choice(enemy['actions'])
+            self.take_action(f"{enemy_action} {enemy['id']} {'player' if target == 'player' else enemy['id']}")
+            for decriment_optional_key in ['vulnerable', 'weak']:
+                if decriment_optional_key in enemy['optional_dict']:
+                    enemy['optional_dict'][decriment_optional_key] = (
+                        enemy['optional_dict'][decriment_optional_key] - 1)
+                    if enemy['optional_dict'][decriment_optional_key] < 0:
+                        enemy['optional_dict'][decriment_optional_key] = 0
         self.start_turn()
 
     def start_turn(self):

--- a/test/data/enemies.toml
+++ b/test/data/enemies.toml
@@ -2,11 +2,17 @@
 [enemies.louse]
 hp = 100
 max_hp = 100
-actions = ["attack 5"]
+actions = [["attack 5", "player"]]
 valid_floors = [1, 2, 3]
 
 [enemies.weakling]
 hp = 1
 max_hp = 1
-actions = ["attack 0"]
+actions = [["attack 0", "player"]]
+valid_floors = [1, 2, 3]
+
+[enemies.blockman]
+hp = 10
+max_hp = 10
+actions = [["apply block 10", "self"]]
 valid_floors = [1, 2, 3]

--- a/test/test_combat.py
+++ b/test/test_combat.py
@@ -109,6 +109,69 @@ class TestCombat(unittest.TestCase):
         combat.take_action("end")
         self.assertEqual(combat.player['hp'], 5)
 
+    def test_attack_blocked_target(self):
+        game_state = {
+            "floor_num": 1,
+            "player": {
+                "deck": {
+                    "strike": 5
+                },
+                "hp": 10,
+                "max_energy": 3,
+                "max_hp": 10
+            }
+        }
+        combat = Combat(game_state, ['blockman'])
+        combat.take_action("end")
+        self.assertEqual(combat.enemy_list[0]['optional_dict']['block'], 10)
+        combat.take_action("play strike_0 blockman")
+        self.assertEqual(combat.enemy_list[0]['optional_dict']['block'], 4)
+        combat.take_action("play strike_1 blockman")
+        self.assertEqual(combat.enemy_list[0]['optional_dict']['block'], 0)
+        self.assertEqual(combat.enemy_list[0]['hp'], 8)
+
+    def test_enemy_attacks_player_with_block(self):
+        game_state = {
+            "floor_num": 1,
+            "player": {
+                "deck": {
+                    "defend": 5
+                },
+                "hp": 10,
+                "max_energy": 3,
+                "max_hp": 10
+            }
+        }
+        combat = Combat(game_state, ['louse'])
+        combat.take_action("play defend_0")
+        self.assertEqual(combat.player['optional_dict']['block'], 5)
+        combat.take_action("end")
+        self.assertEqual(combat.player['optional_dict']['block'], 0)
+        self.assertEqual(combat.player['hp'], 10)
+
+    def test_enemy_with_block_and_vulnerable(self):
+        game_state = {
+            "floor_num": 1,
+            "player": {
+                "deck": {
+                    "bash": 5
+                },
+                "hp": 10,
+                "max_energy": 3,
+                "max_hp": 10
+            }
+        }
+        combat = Combat(game_state, ['blockman'])
+        combat.take_action("end")
+        combat.take_action("play bash_0 blockman")
+        self.assertEqual(combat.enemy_list[0]['optional_dict']['block'], 2)
+        self.assertEqual(combat.enemy_list[0]['optional_dict']['vulnerable'], 2)
+        combat.take_action("end")
+        combat.take_action("play bash_0 blockman")
+        self.assertEqual(combat.enemy_list[0]['optional_dict']['block'], 0)
+        self.assertEqual(combat.enemy_list[0]['optional_dict']['vulnerable'], 3)
+        self.assertEqual(combat.enemy_list[0]['hp'], 10)
+
     def test_game_over_combat_damage(self):
         game_state = {
             "floor_num": 1,
@@ -143,3 +206,4 @@ class TestCombat(unittest.TestCase):
         combat = Combat(game_state, ['weakling'])
         with self.assertRaises(FloorOver):
             combat.take_action("play strike_0 weakling")
+


### PR DESCRIPTION
The commit introduces tests for the new block and vulnerable mechanics in the combat system. Adjustments were made to blocks, player's and enemy's optional dictionary to include them. Tests ensure that these mechanics operate as expected in different scenarios like attacking a blocked target, an enemy attacking a player with a block, and an enemy with block and vulnerability present.